### PR TITLE
Fix multi-tenant collection queries

### DIFF
--- a/weaviate_ui/main.py
+++ b/weaviate_ui/main.py
@@ -86,7 +86,7 @@ def get_class_data(
         try:
             conf = collection.config.get(simple=True)
             if getattr(conf.multi_tenancy_config, "enabled", False):
-                tenant_collection = collection.with_tenant(tenant)
+                tenant_collection = client.collections.get(class_name, tenant=tenant)
             else:
                 logger.warning(
                     f"Tenant '{tenant}' ignored for class '{class_name}' which does not enable multi-tenancy"


### PR DESCRIPTION
## Summary
- pass tenant to `client.collections.get` when querying a class

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899f5507c7c832bb6b3094561e3c33a