### PR TITLE
Add row CRUD operations

### DIFF
--- a/frontend/src/ClassData.tsx
+++ b/frontend/src/ClassData.tsx
@@ -1,5 +1,13 @@
 import React, { useEffect, useRef, useState } from "react";
-import { getClass, getTenants } from "./api.ts";
+import {
+  getClass,
+  getTenants,
+  getObject,
+  insertObject,
+  updateObject,
+  deleteObject,
+  deleteClass,
+} from "./api.ts";
 import {
   ActionType,
   ProTable,
@@ -8,18 +16,22 @@ import {
   ProFormDatePicker,
   QueryFilter,
 } from "@ant-design/pro-components";
-import { Select } from "antd";
+import { Button, Form, Input, Modal, Select, message } from "antd";
 
 export default function ({ pathname, propties }: any) {
   let propertyNames = propties.map((x) => x.name);
+  const className = pathname.split("/").pop();
   let defaultCertainty = 0.65;
   const [keyword, setKeyword] = useState("");
   const [certainty, setCertainty] = useState(defaultCertainty);
   const [tenants, setTenants] = useState<string[]>([]);
   const [selectedTenant, setSelectedTenant] = useState<string | undefined>();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalMode, setModalMode] = useState("insert");
+  const [currentRecord, setCurrentRecord] = useState<any>({});
+  const [form] = Form.useForm();
 
   useEffect(() => {
-    const className = pathname.split("/").pop();
     getTenants(className).then((ts) => {
       setTenants(ts);
       setSelectedTenant(undefined);
@@ -43,6 +55,81 @@ export default function ({ pathname, propties }: any) {
       },
     });
   });
+
+  columns.push({
+    title: "Actions",
+    valueType: "option",
+    render: (_: any, record: any) => [
+      <a key="view" onClick={() => handleView(record.index)}>
+        View
+      </a>,
+      <a key="edit" onClick={() => handleEdit(record)}>
+        Update
+      </a>,
+      <a key="delete" onClick={() => handleDelete(record.index)}>
+        Delete
+      </a>,
+    ],
+  });
+
+  const handleInsert = () => {
+    setModalMode("insert");
+    setCurrentRecord({});
+    form.resetFields();
+    setIsModalOpen(true);
+  };
+
+  const handleEdit = (record: any) => {
+    setModalMode("edit");
+    setCurrentRecord(record);
+    form.setFieldsValue(record);
+    setIsModalOpen(true);
+  };
+
+  const handleView = async (id: string) => {
+    const data = await getObject(className, id, selectedTenant);
+    Modal.info({
+      title: "Object Detail",
+      width: 600,
+      content: <pre>{JSON.stringify(data, null, 2)}</pre>,
+    });
+  };
+
+  const handleDelete = async (id: string) => {
+    await deleteObject(className, id, selectedTenant);
+    message.success("Deleted successfully");
+    ref.current?.reload();
+  };
+
+  const handleDeleteCollection = () => {
+    Modal.confirm({
+      title: "Delete Collection",
+      content: "Are you sure you want to delete this collection?",
+      onOk: async () => {
+        await deleteClass(className);
+        message.success("Collection deleted");
+        window.location.href = "/";
+      },
+    });
+  };
+
+  const onModalOk = async () => {
+    const values = await form.validateFields();
+    if (modalMode === "edit") {
+      await updateObject(
+        className,
+        currentRecord.index,
+        values,
+        selectedTenant,
+      );
+      message.success("Updated successfully");
+    } else {
+      await insertObject(className, values, selectedTenant);
+      message.success("Inserted successfully");
+    }
+    setIsModalOpen(false);
+    ref.current?.reload();
+  };
 
   const ref = useRef<ActionType>();
   return (
@@ -95,6 +182,14 @@ export default function ({ pathname, propties }: any) {
         toolbar={{
           title: "Collection",
           tooltip: "",
+          actions: [
+            <Button type="primary" key="insert" onClick={handleInsert}>
+              Insert
+            </Button>,
+            <Button danger key="delete" onClick={handleDeleteCollection}>
+              Delete Collection
+            </Button>,
+          ],
           search: {
             onSearch: async (value: string) => {
               setKeyword(value);
@@ -150,6 +245,20 @@ export default function ({ pathname, propties }: any) {
         }}
         search={false}
       />
+      <Modal
+        title={modalMode === "edit" ? "Update Row" : "Insert Row"}
+        open={isModalOpen}
+        onOk={onModalOk}
+        onCancel={() => setIsModalOpen(false)}
+      >
+        <Form form={form} layout="vertical">
+          {propertyNames.map((name: string) => (
+            <Form.Item name={name} label={name} key={name}>
+              <Input />
+            </Form.Item>
+          ))}
+        </Form>
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/ClassData.tsx
+++ b/frontend/src/ClassData.tsx
@@ -128,7 +128,7 @@ export default function ({ pathname, propties }: any) {
     const data = await getObject(className, id, selectedTenant);
     Modal.info({
       title: "Object Detail",
-      width: 600,
+      width: "70vw",
       content: (
         <pre style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
           {JSON.stringify(data, null, 2)}
@@ -292,6 +292,7 @@ export default function ({ pathname, propties }: any) {
         open={isModalOpen}
         onOk={onModalOk}
         onCancel={() => setIsModalOpen(false)}
+        width="70vw"
       >
         <Form form={form} layout="vertical">
           {propertyNames.map((name: string) => (

--- a/frontend/src/ClassData.tsx
+++ b/frontend/src/ClassData.tsx
@@ -16,7 +16,13 @@ import {
   ProFormDatePicker,
   QueryFilter,
 } from "@ant-design/pro-components";
-import { Button, Form, Input, Modal, Select, message } from "antd";
+import { Button, Form, Input, Modal, Select, message, Dropdown } from "antd";
+import {
+  EllipsisOutlined,
+  EyeOutlined,
+  EditOutlined,
+  DeleteOutlined,
+} from "@ant-design/icons";
 
 export default function ({ pathname, propties }: any) {
   let propertyNames = propties.map((x) => x.name);
@@ -59,16 +65,48 @@ export default function ({ pathname, propties }: any) {
   columns.push({
     title: "Actions",
     valueType: "option",
+    width: 60,
+    align: "center",
     render: (_: any, record: any) => [
-      <a key="view" onClick={() => handleView(record.index)}>
-        View
-      </a>,
-      <a key="edit" onClick={() => handleEdit(record)}>
-        Update
-      </a>,
-      <a key="delete" onClick={() => handleDelete(record.index)}>
-        Delete
-      </a>,
+      <Dropdown
+        key="actions"
+        menu={{
+          items: [
+            {
+              key: "view",
+              label: (
+                <span>
+                  <EyeOutlined /> View
+                </span>
+              ),
+            },
+            {
+              key: "edit",
+              label: (
+                <span>
+                  <EditOutlined /> Update
+                </span>
+              ),
+            },
+            {
+              key: "delete",
+              label: (
+                <span>
+                  <DeleteOutlined /> Delete
+                </span>
+              ),
+            },
+          ],
+          onClick: ({ key }) => {
+            if (key === "view") handleView(record.index);
+            if (key === "edit") handleEdit(record);
+            if (key === "delete") handleDelete(record.index);
+          },
+        }}
+        trigger={["click"]}
+      >
+        <Button type="text" icon={<EllipsisOutlined />} />
+      </Dropdown>,
     ],
   });
 

--- a/frontend/src/ClassData.tsx
+++ b/frontend/src/ClassData.tsx
@@ -185,7 +185,7 @@ export default function ({ pathname, propties }: any) {
         actionRef={ref}
         params={{ pathname: pathname }}
         columns={columns}
-        onRow={(record) => ({
+        onRow={(record: any) => ({
           onClick: () => handleView(record.index),
         })}
         request={async (

--- a/frontend/src/ClassData.tsx
+++ b/frontend/src/ClassData.tsx
@@ -97,7 +97,8 @@ export default function ({ pathname, propties }: any) {
               ),
             },
           ],
-          onClick: ({ key }) => {
+          onClick: ({ key, domEvent }) => {
+            domEvent.stopPropagation();
             if (key === "view") handleView(record.index);
             if (key === "edit") handleEdit(record);
             if (key === "delete") handleDelete(record.index);
@@ -105,7 +106,11 @@ export default function ({ pathname, propties }: any) {
         }}
         trigger={["click"]}
       >
-        <Button type="text" icon={<EllipsisOutlined />} />
+        <Button
+          type="text"
+          icon={<EllipsisOutlined />}
+          onClick={(e) => e.stopPropagation()}
+        />
       </Dropdown>,
     ],
   });
@@ -180,6 +185,9 @@ export default function ({ pathname, propties }: any) {
         actionRef={ref}
         params={{ pathname: pathname }}
         columns={columns}
+        onRow={(record) => ({
+          onClick: () => handleView(record.index),
+        })}
         request={async (
           // 第一个参数 params 查询表单和 params 参数的结合
           // 第一个参数中一定会有 pageSize 和  current ，这两个参数是 antd 的规范

--- a/frontend/src/ClassData.tsx
+++ b/frontend/src/ClassData.tsx
@@ -91,7 +91,11 @@ export default function ({ pathname, propties }: any) {
     Modal.info({
       title: "Object Detail",
       width: 600,
-      content: <pre>{JSON.stringify(data, null, 2)}</pre>,
+      content: (
+        <pre style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+          {JSON.stringify(data, null, 2)}
+        </pre>
+      ),
     });
   };
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -11,7 +11,7 @@ export const getSchema = (): Promise<Collections> => {
 export const getTenants = (className: string): Promise<string[]> => {
   return fetch(`${host}/class/${className}/tenants`)
     .then((response) => response.json())
-    .then(data => data.tenants)
+    .then((data) => data.tenants)
     .catch((error) => console.log(error));
 };
 
@@ -22,7 +22,7 @@ export const getClass = (
   keyword: string,
   certainty: number,
   properties: [any],
-  tenant?: string
+  tenant?: string,
 ) => {
   const queryParams = new URLSearchParams({
     certainty: certainty.toString(),
@@ -39,6 +39,85 @@ export const getClass = (
       "Content-Type": "application/json",
     },
     body: JSON.stringify(properties),
+  })
+    .then((response) => response.json())
+    .catch((error) => console.log(error));
+};
+
+export const getObject = (className: string, id: string, tenant?: string) => {
+  const queryParams = new URLSearchParams();
+  if (tenant) {
+    queryParams.append("tenant", tenant);
+  }
+  return fetch(
+    `${host}/class/${className}/object/${id}?${queryParams.toString()}`,
+  )
+    .then((response) => response.json())
+    .catch((error) => console.log(error));
+};
+
+export const insertObject = (
+  className: string,
+  properties: any,
+  tenant?: string,
+) => {
+  const queryParams = new URLSearchParams();
+  if (tenant) {
+    queryParams.append("tenant", tenant);
+  }
+  return fetch(`${host}/class/${className}/object?${queryParams.toString()}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(properties),
+  })
+    .then((response) => response.json())
+    .catch((error) => console.log(error));
+};
+
+export const updateObject = (
+  className: string,
+  id: string,
+  properties: any,
+  tenant?: string,
+) => {
+  const queryParams = new URLSearchParams();
+  if (tenant) {
+    queryParams.append("tenant", tenant);
+  }
+  return fetch(
+    `${host}/class/${className}/object/${id}?${queryParams.toString()}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(properties),
+    },
+  )
+    .then((response) => response.json())
+    .catch((error) => console.log(error));
+};
+
+export const deleteObject = (
+  className: string,
+  id: string,
+  tenant?: string,
+) => {
+  const queryParams = new URLSearchParams();
+  if (tenant) {
+    queryParams.append("tenant", tenant);
+  }
+  return fetch(
+    `${host}/class/${className}/object/${id}?${queryParams.toString()}`,
+    {
+      method: "DELETE",
+    },
+  )
+    .then((response) => response.json())
+    .catch((error) => console.log(error));
+};
+
+export const deleteClass = (className: string) => {
+  return fetch(`${host}/class/${className}`, {
+    method: "DELETE",
   })
     .then((response) => response.json())
     .catch((error) => console.log(error));

--- a/weaviate_ui/main.py
+++ b/weaviate_ui/main.py
@@ -7,7 +7,6 @@ from loguru import logger
 from starlette.middleware.cors import CORSMiddleware
 from starlette.staticfiles import StaticFiles
 from weaviate.classes.init import Auth
-from pydantic import BaseModel
 from uuid import uuid4
 from typing import Any, Dict
 
@@ -118,11 +117,6 @@ def get_class_data(
     return {"data": response.objects, "count": count_response.total_count}
 
 
-class ObjectPayload(BaseModel):
-    uuid: str | None = None
-    properties: Dict[str, Any]
-
-
 def _collection_with_tenant(class_name: str, tenant: str | None):
     collection = client.collections.get(class_name)
     if tenant:
@@ -134,17 +128,24 @@ def _collection_with_tenant(class_name: str, tenant: str | None):
 def get_object(class_name: str, object_id: str, tenant: str | None = None):
     collection = _collection_with_tenant(class_name, tenant)
     try:
-        return collection.data.get(object_id)
+        obj = collection.query.fetch_object_by_id(object_id)
+        if obj is None:
+            raise HTTPException(status_code=404, detail="Object not found")
+        return obj
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=404, detail=str(e))
 
 
 @app.post("/class/{class_name}/object")
-def insert_object(class_name: str, payload: ObjectPayload, tenant: str | None = None):
+def insert_object(
+    class_name: str, properties: Dict[str, Any], tenant: str | None = None
+):
     collection = _collection_with_tenant(class_name, tenant)
-    uid = payload.uuid or str(uuid4())
+    uid = properties.pop("uuid", str(uuid4()))
     try:
-        collection.data.insert(payload.properties, uuid=uid)
+        collection.data.insert(properties, uuid=uid)
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
     return {"uuid": uid}
@@ -169,7 +170,7 @@ def update_object(
 def delete_object(class_name: str, object_id: str, tenant: str | None = None):
     collection = _collection_with_tenant(class_name, tenant)
     try:
-        collection.data.delete(object_id)
+        collection.data.delete_by_id(object_id)
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
     return {"uuid": object_id}

--- a/weaviate_ui/main.py
+++ b/weaviate_ui/main.py
@@ -2,11 +2,14 @@ import os
 
 import weaviate
 from dotenv import load_dotenv
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from loguru import logger
 from starlette.middleware.cors import CORSMiddleware
 from starlette.staticfiles import StaticFiles
 from weaviate.classes.init import Auth
+from pydantic import BaseModel
+from uuid import uuid4
+from typing import Any, Dict
 
 load_dotenv(override=True)
 
@@ -79,7 +82,9 @@ def get_class_data(
     tenant: str | None = None,
 ):
     logger.info(keyword)
-    logger.info(f"Fetching data for class '{class_name}' with keyword '{keyword}' and tenant '{tenant}'")
+    logger.info(
+        f"Fetching data for class '{class_name}' with keyword '{keyword}' and tenant '{tenant}'"
+    )
     collection = client.collections.get(class_name)
     tenant_collection = collection
     if tenant:
@@ -88,13 +93,15 @@ def get_class_data(
             is_enabled = conf.multi_tenancy_config.enabled
             print(f"Multi-tenancy enabled: {is_enabled}")
             if is_enabled:
-               tenant_collection = collection.with_tenant(tenant)
+                tenant_collection = collection.with_tenant(tenant)
             else:
                 logger.warning(
                     f"Tenant '{tenant}' ignored for class '{class_name}' which does not enable multi-tenancy"
                 )
         except Exception as e:
-            logger.error(f"Error fetching multi-tenancy config for class '{class_name}': {e}")
+            logger.error(
+                f"Error fetching multi-tenancy config for class '{class_name}': {e}"
+            )
     paginate = {"limit": limit, "offset": offset}
 
     if keyword:
@@ -109,6 +116,72 @@ def get_class_data(
         count_response = tenant_collection.aggregate.over_all(total_count=True)
 
     return {"data": response.objects, "count": count_response.total_count}
+
+
+class ObjectPayload(BaseModel):
+    uuid: str | None = None
+    properties: Dict[str, Any]
+
+
+def _collection_with_tenant(class_name: str, tenant: str | None):
+    collection = client.collections.get(class_name)
+    if tenant:
+        collection = collection.with_tenant(tenant)
+    return collection
+
+
+@app.get("/class/{class_name}/object/{object_id}")
+def get_object(class_name: str, object_id: str, tenant: str | None = None):
+    collection = _collection_with_tenant(class_name, tenant)
+    try:
+        return collection.data.get(object_id)
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+
+@app.post("/class/{class_name}/object")
+def insert_object(class_name: str, payload: ObjectPayload, tenant: str | None = None):
+    collection = _collection_with_tenant(class_name, tenant)
+    uid = payload.uuid or str(uuid4())
+    try:
+        collection.data.insert(payload.properties, uuid=uid)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"uuid": uid}
+
+
+@app.put("/class/{class_name}/object/{object_id}")
+def update_object(
+    class_name: str,
+    object_id: str,
+    properties: Dict[str, Any],
+    tenant: str | None = None,
+):
+    collection = _collection_with_tenant(class_name, tenant)
+    try:
+        collection.data.update(object_id, properties)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"uuid": object_id}
+
+
+@app.delete("/class/{class_name}/object/{object_id}")
+def delete_object(class_name: str, object_id: str, tenant: str | None = None):
+    collection = _collection_with_tenant(class_name, tenant)
+    try:
+        collection.data.delete(object_id)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"uuid": object_id}
+
+
+@app.delete("/class/{class_name}")
+def delete_class(class_name: str):
+    try:
+        client.collections.delete(class_name)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"class_name": class_name}
 
 
 app.mount("/", StaticFiles(directory="static", html=True), name="static")


### PR DESCRIPTION
## Summary
- add front-end table actions for viewing, updating, deleting, and inserting rows
- expose backend CRUD endpoints for class objects
- wire up new API helpers for object operations
- allow deleting entire collections from the UI

## Testing
- `poetry install`
- `black .`
- `npx prettier -w frontend/src/api.ts frontend/src/ClassData.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689ac4e16a7c832b8c9cfc979d20f3b1