### PR TITLE
Add sorting options for collections

### DIFF
--- a/frontend/src/Welcome.tsx
+++ b/frontend/src/Welcome.tsx
@@ -20,6 +20,7 @@ export default function () {
     vectorizer: Object.values(schema.vector_config || [])
       .map((config) => config.vectorizer.vectorizer)
       .join(","),
+    modified: schema.last_update_time_unix,
     key: schema.name,
     detail: schema,
   }));
@@ -27,6 +28,7 @@ export default function () {
     {
       title: "Collection",
       dataIndex: "className",
+      sorter: (a, b) => a.className.localeCompare(b.className),
     },
     {
       title: "Description",
@@ -39,6 +41,13 @@ export default function () {
     {
       title: "Vectorizer",
       dataIndex: "vectorizer",
+    },
+    {
+      title: "Modified",
+      dataIndex: "modified",
+      sorter: (a, b) => (a.modified ?? 0) - (b.modified ?? 0),
+      render: (_: any, record: any) =>
+        record.modified ? new Date(record.modified).toLocaleString() : "",
     },
     {
       title: "Detail",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -53,6 +53,7 @@ interface Collection {
   vectorizer_config: null;
   vectorizer: null;
   vector_config: VectorConfig;
+  last_update_time_unix?: number;
 }
 
 interface Collections {

--- a/weaviate_ui/main.py
+++ b/weaviate_ui/main.py
@@ -9,6 +9,7 @@ from starlette.staticfiles import StaticFiles
 from weaviate.classes.init import Auth
 from uuid import uuid4
 from typing import Any, Dict
+from dataclasses import asdict
 
 load_dotenv(override=True)
 
@@ -57,7 +58,18 @@ client = weaviate.connect_to_custom(
 
 @app.get("/schema")
 def schema():
-    return client.collections.list_all()
+    configs = client.collections.list_all()
+    response = client.collections._connection.get(
+        path="/schema", error_msg="Get schema"
+    )
+    raw = response.json()
+    update_map = {
+        cl["class"]: cl.get("lastUpdateTimeUnix") for cl in raw.get("classes", [])
+    }
+    return {
+        name: {**asdict(cfg), "last_update_time_unix": update_map.get(name)}
+        for name, cfg in configs.items()
+    }
 
 
 @app.get("/class/{class_name}/tenants")


### PR DESCRIPTION
## Summary
- expose last update time for each collection in backend schema endpoint
- allow sorting collections by name and modification date in UI
- add typing for last update timestamp

## Testing
- `npx prettier -w src`
- `black .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f7b1f305c832b8085ab38767e46d7