### PR TITLE
docs: expand README with features and development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,50 @@ Weaviate-UI is a web client for interacting with the Weaviate.
 
 ## Features
 
-- Schema query
-- Data search
+- Browse the schema and inspect classes
+- Perform semantic or keyword data searches
+- View and manage objects (create, update and delete)
+- Multi-tenant aware with tenant selection
+
+## Local Development
+
+1. Install backend dependencies:
+
+   ```bash
+   poetry install
+   ```
+
+2. Install frontend dependencies:
+
+   ```bash
+   cd frontend
+   yarn
+   cd ..
+   ```
+
+3. Start the backend server:
+
+   ```bash
+   uvicorn weaviate_ui.main:app --reload --host 0.0.0.0 --port 7777
+   ```
+
+4. In another terminal start the frontend development server:
+
+   ```bash
+   cd frontend
+   yarn dev
+   ```
+
+5. Build the frontend for production:
+
+   ```bash
+   cd frontend
+   yarn build
+   ```
 
 ## Usage V4
 
-See `compose.yml` and adjust environment variables to your need. By default it will look for a locally hosted weaviate on the default 8080 port. Set `WEAVIATE_AUTH_CREDENTIALS` if authentication is required.
+See `compose.yml` and adjust environment variables as needed. By default it connects to a locally hosted Weaviate on port 8080. Set `WEAVIATE_AUTH_CREDENTIALS` if authentication is required.
 
 ```bash
 $ docker-compose up

--- a/frontend/src/customMenu.ts
+++ b/frontend/src/customMenu.ts
@@ -1,24 +1,24 @@
 export default [
-    {
-        path: '/',
-        name: '😈 欢迎',
+  {
+    path: "/",
+    name: "😈 欢迎",
+    routes: [
+      {
+        path: "/welcome",
+        name: "one",
         routes: [
-            {
-                path: '/welcome',
-                name: 'one',
-                routes: [
-                    {
-                        path: '/welcome/welcome',
-                        name: 'two',
-                        exact: true,
-                    },
-                ],
-            },
+          {
+            path: "/welcome/welcome",
+            name: "two",
+            exact: true,
+          },
         ],
-    },
-    {
-        path: '/demo',
-        name: '例子',
-        component: './Welcome',
-    },
+      },
+    ],
+  },
+  {
+    path: "/demo",
+    name: "例子",
+    component: "./Welcome",
+  },
 ];

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,12 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
-import {ConfigProvider} from "antd";
-import en_US from 'antd/locale/en_US';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+import "./index.css";
+import { ConfigProvider } from "antd";
+import en_US from "antd/locale/en_US";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-    <ConfigProvider locale={en_US}>
-        <App />
-    </ConfigProvider>
-  ,
-)
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <ConfigProvider locale={en_US}>
+    <App />
+  </ConfigProvider>,
+);

--- a/weaviate_ui/weaviate_client.py
+++ b/weaviate_ui/weaviate_client.py
@@ -7,8 +7,10 @@ load_dotenv(override=True)
 WEAVIATE_API_KEYS = os.getenv("WEAVIATE_API_KEYS", None)
 client = weaviate.Client(
     url=os.getenv("WEAVIATE_URL"),
-    auth_client_secret=weaviate.AuthApiKey(api_key=WEAVIATE_API_KEYS) if WEAVIATE_API_KEYS else None,
+    auth_client_secret=(
+        weaviate.AuthApiKey(api_key=WEAVIATE_API_KEYS) if WEAVIATE_API_KEYS else None
+    ),
 )
 
-if __name__ == '__main__' :
-    print(client.query.get("Lens",['body']).with_limit(10).do())
+if __name__ == "__main__":
+    print(client.query.get("Lens", ["body"]).with_limit(10).do())


### PR DESCRIPTION
## Summary
- document schema browsing, data search, CRUD and multi-tenant features
- add local development setup and refine container usage notes
- format backend and frontend sources

## Testing
- `poetry install`
- `cd frontend && yarn`
- `black --check weaviate_ui`
- `npx prettier -c frontend/src`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abec775ab0832b9331e2847ca284e2